### PR TITLE
[fix/ACP-112] Apple Login Firebase sign-in error fix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   sign_in_with_apple: ^4.1.0
   google_sign_in: ^5.4.1
   kakao_flutter_sdk_user: ^1.2.1
-  firebase_auth: ^3.9.0
+  firebase_auth: ^3.11.2
 
   ## Utils
   very_good_analysis: ^3.0.1


### PR DESCRIPTION
## 에러 내용

Apple 로그인 할 때 Crash 에러 발생

```
Thread 1: "*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[3]"
```

## 수정 내용
원인: /lib/provider/login/apple_login.dart - line: 20
- 여기서 firebase 로그인 에러남

수정: firebase_auth 버전 올리니까 해결됨.