### PR TITLE
[fix/#41] 업로드 화면 이슈 수정

### DIFF
--- a/lib/ui/view/email_login_view.dart
+++ b/lib/ui/view/email_login_view.dart
@@ -36,6 +36,7 @@ class _EmailLoginViewState extends State<EmailLoginView>
     return KeyboardDismissOnTap(
       child: KeyboardVisibilityBuilder(
         builder: (context, visible) {
+          final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
           return Scaffold(
             resizeToAvoidBottomInset: false,
             appBar: buildBackAppBar(context),
@@ -123,6 +124,7 @@ class _EmailLoginViewState extends State<EmailLoginView>
                         ),
                       ),
                     ),
+                    SizedBox(height: keyboardHeight)
                   ],
                 ),
               ),

--- a/lib/ui/view/email_sign_up_view.dart
+++ b/lib/ui/view/email_sign_up_view.dart
@@ -36,6 +36,7 @@ class _EmailSignUpViewState extends State<EmailSignUpView>
     return KeyboardDismissOnTap(
       child: KeyboardVisibilityBuilder(
         builder: (context, visible) {
+          final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
           return Scaffold(
             resizeToAvoidBottomInset: false,
             appBar: buildBackAppBar(context),
@@ -122,6 +123,7 @@ class _EmailSignUpViewState extends State<EmailSignUpView>
                         ),
                       ),
                     ),
+                    SizedBox(height: keyboardHeight),
                   ],
                 ),
               ),

--- a/lib/ui/view/link_detail_view.dart
+++ b/lib/ui/view/link_detail_view.dart
@@ -48,6 +48,7 @@ class LinkDetailView extends StatelessWidget {
           builder: (context, visible) {
             return BlocBuilder<DetailEditCubit, EditState>(
               builder: (cubitContext, state) {
+                final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
                 return Scaffold(
                   resizeToAvoidBottomInset: false,
                   appBar: AppBar(
@@ -82,11 +83,12 @@ class LinkDetailView extends StatelessWidget {
                     systemOverlayStyle: SystemUiOverlayStyle.dark,
                   ),
                   body: buildBody(
+                    scrollController,
+                    state,
                     link,
                     cubitContext,
-                    state,
-                    scrollController,
                     isMyLink,
+                    keyboardHeight,
                   ),
                   bottomSheet: Builder(
                     builder: (_) {
@@ -118,11 +120,12 @@ class LinkDetailView extends StatelessWidget {
   }
 
   Widget buildBody(
-    Link link,
-    BuildContext context,
-    EditState state,
     ScrollController scrollController,
+    EditState state,
+    Link link,
+    BuildContext cubitContext,
     bool isMyLink,
+    double keyboardHeight,
   ) {
     return SingleChildScrollView(
       controller: scrollController,
@@ -162,7 +165,7 @@ class LinkDetailView extends StatelessWidget {
                       child: Image.network(
                         link.image ?? '',
                         fit: BoxFit.cover,
-                        width: MediaQuery.of(context).size.width - 48,
+                        width: MediaQuery.of(cubitContext).size.width - 48,
                         height: 193,
                         errorBuilder: (_, __, ___) {
                           return Container(
@@ -173,7 +176,7 @@ class LinkDetailView extends StatelessWidget {
                                 topRight: Radius.circular(10),
                               ),
                             ),
-                            width: MediaQuery.of(context).size.width - 48,
+                            width: MediaQuery.of(cubitContext).size.width - 48,
                             height: 10,
                           );
                         },
@@ -250,14 +253,14 @@ class LinkDetailView extends StatelessWidget {
                       FocusManager.instance.primaryFocus?.unfocus();
                       Future.delayed(
                         const Duration(milliseconds: 200),
-                        context.read<DetailEditCubit>().toggle,
+                        cubitContext.read<DetailEditCubit>().toggle,
                       );
                     },
                     onDoubleTap: () {
                       FocusManager.instance.primaryFocus?.unfocus();
                       Future.delayed(
                         const Duration(milliseconds: 200),
-                        context.read<DetailEditCubit>().toggle,
+                        cubitContext.read<DetailEditCubit>().toggle,
                       );
                     },
                     child: Padding(
@@ -319,8 +322,9 @@ class LinkDetailView extends StatelessWidget {
                           minHeight: 120,
                         ),
                         child: TextField(
-                          controller:
-                              context.read<DetailEditCubit>().textController,
+                          controller: cubitContext
+                              .read<DetailEditCubit>()
+                              .textController,
                           style: const TextStyle(
                             fontSize: 14,
                             color: grey700,
@@ -344,6 +348,7 @@ class LinkDetailView extends StatelessWidget {
                 }
               },
             ),
+            SizedBox(height: keyboardHeight),
           ],
         ),
       ),

--- a/lib/ui/view/sign_up_nickname_view.dart
+++ b/lib/ui/view/sign_up_nickname_view.dart
@@ -34,10 +34,11 @@ class SignUpNicknameView extends StatelessWidget {
               return KeyboardDismissOnTap(
                 child: KeyboardVisibilityBuilder(
                   builder: (context, visible) {
+                    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
                     return Scaffold(
                       resizeToAvoidBottomInset: false,
                       appBar: buildBackAppBar(context),
-                      body: buildBody(context, state),
+                      body: buildBody(context, state, keyboardHeight),
                       bottomSheet: buildBottomSheetButton(
                         context: context,
                         text: '확인',
@@ -64,40 +65,35 @@ class SignUpNicknameView extends StatelessWidget {
     );
   }
 
-  Widget buildBody(BuildContext context, ButtonState state) {
+  Widget buildBody(BuildContext context, ButtonState state, double keyboardHeight) {
     return SafeArea(
       child: Container(
         margin: const EdgeInsets.fromLTRB(24, 16, 24, 16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+            buildTitleText(),
+            Stack(
+              alignment: Alignment.centerRight,
               children: [
-                buildTitleText(),
-                Stack(
-                  alignment: Alignment.centerRight,
-                  children: [
-                    buildNicknameField(context, state),
-                    if (state == ButtonState.enabled)
-                      const Padding(
-                        padding: EdgeInsets.only(
-                          top: 40,
-                          right: 8,
-                        ),
-                        child: Icon(
-                          Icons.check_rounded,
-                          color: primaryTab,
-                          size: 20,
-                        ),
-                      )
-                    else
-                      const SizedBox.shrink(),
-                  ],
-                ),
+                buildNicknameField(context, state),
+                if (state == ButtonState.enabled)
+                  const Padding(
+                    padding: EdgeInsets.only(
+                      top: 40,
+                      right: 8,
+                    ),
+                    child: Icon(
+                      Icons.check_rounded,
+                      color: primaryTab,
+                      size: 20,
+                    ),
+                  )
+                else
+                  const SizedBox.shrink(),
               ],
             ),
+            SizedBox(height: keyboardHeight),
           ],
         ),
       ),
@@ -182,9 +178,5 @@ class SignUpNicknameView extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  double getBottomMargin(bool visible) {
-    return visible ? 16 : 37;
   }
 }

--- a/lib/ui/view/upload_view.dart
+++ b/lib/ui/view/upload_view.dart
@@ -166,7 +166,9 @@ class _UploadViewState extends State<UploadView> {
                             ),
                           ),
                         ),
-                        SizedBox(height: keyboardHeight,)
+                        SizedBox(
+                          height: keyboardHeight,
+                        )
                       ],
                     ),
                   ),
@@ -200,56 +202,48 @@ class _UploadViewState extends State<UploadView> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                padding: const EdgeInsets.all(1),
+              DecoratedBox(
                 decoration: BoxDecoration(
-                  borderRadius: const BorderRadius.all(
-                    Radius.circular(12),
-                  ),
-                  color: linkError ? redError2 : grey100,
+                  border: Border.all(color: linkError ? redError2 : grey100),
+                  borderRadius: const BorderRadius.all(Radius.circular(12)),
+                  color: grey100,
                 ),
-                child: DecoratedBox(
-                  decoration: const BoxDecoration(
-                    borderRadius: BorderRadius.all(Radius.circular(12)),
-                    color: grey100,
-                  ),
-                  child: SingleChildScrollView(
-                    padding: EdgeInsets.zero,
-                    controller: firstScrollController,
-                    child: SizedBox(
-                      height: 80,
-                      child: TextField(
-                        controller: linkTextController,
-                        style: const TextStyle(
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.zero,
+                  controller: firstScrollController,
+                  child: SizedBox(
+                    height: 80,
+                    child: TextField(
+                      controller: linkTextController,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        height: 16.7 / 14,
+                        color: grey600,
+                        letterSpacing: -0.3,
+                      ),
+                      cursorColor: primary600,
+                      keyboardType: TextInputType.multiline,
+                      maxLines: null,
+                      decoration: const InputDecoration(
+                        border: InputBorder.none,
+                        focusedBorder: InputBorder.none,
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          vertical: 15,
+                          horizontal: 16,
+                        ),
+                        hintText: '링크를 여기에 불러주세요',
+                        hintStyle: TextStyle(
+                          color: grey400,
                           fontSize: 14,
-                          height: 16.7 / 14,
-                          color: grey600,
                           letterSpacing: -0.3,
                         ),
-                        cursorColor: primary600,
-                        keyboardType: TextInputType.multiline,
-                        maxLines: null,
-                        decoration: const InputDecoration(
-                          border: InputBorder.none,
-                          focusedBorder: InputBorder.none,
-                          isDense: true,
-                          contentPadding: EdgeInsets.symmetric(
-                            vertical: 15,
-                            horizontal: 16,
-                          ),
-                          hintText: '링크를 여기에 불러주세요',
-                          hintStyle: TextStyle(
-                            color: grey400,
-                            fontSize: 14,
-                            letterSpacing: -0.3,
-                          ),
-                        ),
-                        onChanged: (value) => setState(() {
-                          if (value.isNotEmpty) {
-                            buttonState = ButtonState.enabled;
-                          }
-                        }),
                       ),
+                      onChanged: (value) => setState(() {
+                        if (value.isNotEmpty) {
+                          buttonState = ButtonState.enabled;
+                        }
+                      }),
                     ),
                   ),
                 ),

--- a/lib/ui/view/upload_view.dart
+++ b/lib/ui/view/upload_view.dart
@@ -58,6 +58,8 @@ class _UploadViewState extends State<UploadView> {
       child: KeyboardDismissOnTap(
         child: KeyboardVisibilityBuilder(
           builder: (context, visible) {
+            final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+
             return Scaffold(
               resizeToAvoidBottomInset: false,
               backgroundColor: Colors.white,
@@ -164,6 +166,7 @@ class _UploadViewState extends State<UploadView> {
                             ),
                           ),
                         ),
+                        SizedBox(height: keyboardHeight,)
                       ],
                     ),
                   ),


### PR DESCRIPTION
## 🙋 작업 목적(이슈 내용)

- #41 
- Scaffold의 resizeToAvoidBottomInset 옵션을 false로 사용 시 키보드 길이를 따로 늘려줘야 함

## 🔧 주요 작업 내용

- 키보드 입력과 플로팅 버튼 동시에 있는 화면 수정
- borderRadius와 border 동시 사용

## 🙏 To Reviewers

- Scaffold의 bottomSheet 영역에 버튼을 배치하는 방식 위주로 살펴보면 좋을 것 같습니다.
- 전에는 border와 borderRadius를 같이 설정하는게 안되는 것 같았는데 지금은 잘 되네요 ㅎㅎ
