### PR TITLE
[fix/#62 fix/#65] 토스트 (스낵바) 팝업 위치 수정 및 저장시 토스트 뜨도록 수정

### DIFF
--- a/lib/const/consts.dart
+++ b/lib/const/consts.dart
@@ -1,0 +1,3 @@
+enum NavigatorPopResult {
+  saveLink,
+}

--- a/lib/ui/page/home/home_page.dart
+++ b/lib/ui/page/home/home_page.dart
@@ -438,6 +438,7 @@ class HomePage extends StatelessWidget {
                             .read<LinksFromSelectedJobGroupCubit>()
                             .getSelectedJobLinks(selectedJobGroupId, 0);
                         totalLinks.clear();
+
                       },
                     );
                   },

--- a/lib/ui/page/my_folder/my_folder_page.dart
+++ b/lib/ui/page/my_folder/my_folder_page.dart
@@ -80,7 +80,7 @@ class _MyFolderPageState extends State<MyFolderPage>
                             final profile = state.profile;
                             return InkWell(
                               onTap: () {
-                                showBottomToast('폴더가 삭제되었어요!');
+                                showBottomToast( context:context, '폴더가 삭제되었어요!');
                               },
                               child: Column(
                                 mainAxisSize: MainAxisSize.min,
@@ -593,7 +593,7 @@ class _MyFolderPageState extends State<MyFolderPage>
                           Navigator.pop(context, true);
                           cubit.getFolders();
                           if (result) {
-                            showBottomToast('폴더가 삭제되었어요!');
+                            showBottomToast(context:context,'폴더가 삭제되었어요!');
                           }
                         });
                       },
@@ -612,7 +612,8 @@ class _MyFolderPageState extends State<MyFolderPage>
     ).then((bool? value) {
       Navigator.pop(context);
       if (value ?? false) {
-        showBottomToast('폴더가 삭제되었어요!');
+        // 삭제 토스트가 두번뜨는 이슈 수정
+        //showBottomToast(context:context,'폴더가 삭제되었어요!');
       }
     });
   }

--- a/lib/ui/page/my_page/my_page.dart
+++ b/lib/ui/page/my_page/my_page.dart
@@ -38,7 +38,7 @@ class MyPage extends StatelessWidget {
                             Routes.home,
                             arguments: {'index': 3},
                           );
-                          showBottomToast('프로필 이미지를 변경했어요!');
+                          showBottomToast(context: context, '프로필 이미지를 변경했어요!');
                         }
                       });
                     },
@@ -169,7 +169,7 @@ class MyPage extends StatelessWidget {
                         Navigator.pushReplacementNamed(context, Routes.login);
                       } else {
                         Navigator.of(context).pop(true);
-                        showBottomToast('회원탈퇴 실패');
+                        showBottomToast(context: context, '회원탈퇴 실패');
                       }
                     });
                   },

--- a/lib/ui/view/email_login_view.dart
+++ b/lib/ui/view/email_login_view.dart
@@ -3,8 +3,6 @@
 import 'dart:async';
 
 import 'package:ac_project_app/const/colors.dart';
-import 'package:ac_project_app/cubits/login/login_cubit.dart';
-import 'package:ac_project_app/cubits/login/login_type.dart';
 import 'package:ac_project_app/provider/api/user/user_api.dart';
 import 'package:ac_project_app/provider/login/email_login.dart';
 import 'package:ac_project_app/provider/share_data_provider.dart';
@@ -17,7 +15,6 @@ import 'package:ac_project_app/util/logger.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 
 class EmailLoginView extends StatefulWidget {
@@ -140,7 +137,7 @@ class _EmailLoginViewState extends State<EmailLoginView>
               onPressed: buttonState
                   ? () {
                       if (isEmailSent) {
-                        showBottomToast('이미 이메일이 발송 되었습니다.');
+                        showBottomToast(context: context, '이미 이메일이 발송 되었습니다.');
                       } else {
                         Email.send(context, emailString, '로그인');
                         setState(() {
@@ -226,7 +223,8 @@ class _EmailLoginViewState extends State<EmailLoginView>
               );
               Future.delayed(
                 const Duration(milliseconds: 500),
-                () => showBottomToast('가입된 계정이 없어 회원 가입 화면으로 이동합니다.'),
+                () => showBottomToast(
+                    context: context, '가입된 계정이 없어 회원 가입 화면으로 이동합니다.'),
               );
             } else {
               ShareDataProvider.loadServerData();
@@ -236,7 +234,7 @@ class _EmailLoginViewState extends State<EmailLoginView>
                 Routes.home,
                 (_) => false,
                 arguments: {'index': 0},
-            );
+              );
             }
           },
           error: (msg) {

--- a/lib/ui/view/email_sign_up_view.dart
+++ b/lib/ui/view/email_sign_up_view.dart
@@ -135,7 +135,7 @@ class _EmailSignUpViewState extends State<EmailSignUpView>
               onPressed: buttonState
                   ? () {
                       if (isEmailSent) {
-                        showBottomToast('이미 이메일이 발송 되었습니다.');
+                        showBottomToast(context:context,'이미 이메일이 발송 되었습니다.');
                       } else {
                         Email.send(context, emailString, '가입');
                         setState(() {
@@ -221,7 +221,7 @@ class _EmailSignUpViewState extends State<EmailSignUpView>
                 },
               );
             } else {
-              showBottomToast('가입된 계정이 이미 있습니다!');
+              showBottomToast(context:context,'가입된 계정이 이미 있습니다!');
             }
           },
           error: (msg) {

--- a/lib/ui/view/home_view.dart
+++ b/lib/ui/view/home_view.dart
@@ -1,4 +1,5 @@
 import 'package:ac_project_app/const/colors.dart';
+import 'package:ac_project_app/const/consts.dart';
 import 'package:ac_project_app/cubits/folders/folder_view_type_cubit.dart';
 import 'package:ac_project_app/cubits/folders/get_my_folders_cubit.dart';
 import 'package:ac_project_app/cubits/folders/get_user_folders_cubit.dart';
@@ -11,6 +12,7 @@ import 'package:ac_project_app/routes.dart';
 import 'package:ac_project_app/ui/page/home/home_page.dart';
 import 'package:ac_project_app/ui/page/my_folder/my_folder_page.dart';
 import 'package:ac_project_app/ui/page/my_page/my_page.dart';
+import 'package:ac_project_app/ui/widget/bottom_toast.dart';
 import 'package:ac_project_app/util/get_widget_arguments.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -151,9 +153,7 @@ class _HomeViewState extends State<HomeView> with WidgetsBindingObserver {
                       context.read<LinksFromSelectedJobGroupCubit>().refresh();
                       context.read<HomeViewCubit>().moveTo(index);
                     } else if (index == 1) {
-                      Navigator.pushNamed(context, Routes.upload).then(
-                        (value) => setState(() {}),
-                      );
+                      pushUploadView(context);
                     } else if (index == 2) {
                       context.read<GetFoldersCubit>().getFolders();
                       context.read<HomeViewCubit>().moveTo(index);
@@ -165,6 +165,25 @@ class _HomeViewState extends State<HomeView> with WidgetsBindingObserver {
               );
             },
           );
+        },
+      ),
+    );
+  }
+
+  void pushUploadView(BuildContext context) {
+    Navigator.pushNamed(context, Routes.upload).then(
+      (value) => setState(
+        () {
+          if (NavigatorPopResult.saveLink == value) {
+            showBottomToast(
+              context: context,
+              '링크가 저장되었어요!',
+              callback: () {
+                context.read<GetFoldersCubit>().getFolders();
+                context.read<HomeViewCubit>().moveTo(2);
+              },
+            );
+          }
         },
       ),
     );

--- a/lib/ui/view/login_view.dart
+++ b/lib/ui/view/login_view.dart
@@ -93,7 +93,8 @@ class LoginView extends StatelessWidget {
               ).then((_) => context.read<LoginCubit>().showNothing());
               Future.delayed(
                 const Duration(milliseconds: 500),
-                () => showBottomToast('가입된 계정이 없어 회원 가입 화면으로 이동합니다.'),
+                () => showBottomToast(
+                    context: context, '가입된 계정이 없어 회원 가입 화면으로 이동합니다.'),
               );
             } else {
               ShareDataProvider.loadServerData();

--- a/lib/ui/view/report_view.dart
+++ b/lib/ui/view/report_view.dart
@@ -262,7 +262,7 @@ class _ReportViewState extends State<ReportView> {
           Navigator.pop(context);
           Future.delayed(
             const Duration(milliseconds: 300),
-            () => showBottomToast('신고가 접수되었어요!'),
+            () => showBottomToast(context: context, '신고가 접수되었어요!'),
           );
         } else if (type == ReportResultType.duplicated) {
           showPopUp(

--- a/lib/ui/view/upload_view.dart
+++ b/lib/ui/view/upload_view.dart
@@ -1,8 +1,10 @@
 // ignore_for_file: avoid_positional_boolean_parameters
 
 import 'package:ac_project_app/const/colors.dart';
+import 'package:ac_project_app/const/consts.dart';
 import 'package:ac_project_app/cubits/folders/folders_state.dart';
 import 'package:ac_project_app/cubits/folders/get_my_folders_cubit.dart';
+import 'package:ac_project_app/cubits/home_view_cubit.dart';
 import 'package:ac_project_app/cubits/links/upload_link_cubit.dart';
 import 'package:ac_project_app/cubits/links/upload_result_state.dart';
 import 'package:ac_project_app/cubits/sign_up/button_state_cubit.dart';
@@ -51,6 +53,9 @@ class _UploadViewState extends State<UploadView> {
 
     return MultiBlocProvider(
       providers: [
+        BlocProvider(
+          create: (_) => HomeViewCubit((args['index'] as int?) ?? 0),
+        ),
         BlocProvider<GetFoldersCubit>(
           create: (_) => GetFoldersCubit(excludeUnclassified: true),
         ),
@@ -308,15 +313,7 @@ class _UploadViewState extends State<UploadView> {
         )
         .then((result) {
       if (result == UploadResultState.success) {
-        showPopUp(
-          title: '저장완료!',
-          content: '링크가 폴더에 담겼어요',
-          parentContext: context,
-          callback: () {
-            Navigator.pop(context);
-            Navigator.pop(context);
-          },
-        );
+        Navigator.pop(context, NavigatorPopResult.saveLink);
       } else if (result == UploadResultState.duplicated) {
         showPopUp(
           title: '업로드 실패',

--- a/lib/ui/widget/bottom_dialog.dart
+++ b/lib/ui/widget/bottom_dialog.dart
@@ -63,7 +63,10 @@ Future<bool?> showMyLinkOptionsDialog(
                             Clipboard.setData(
                               ClipboardData(text: link.url ?? ''),
                             ).then(
-                              (value) => showBottomToast('링크 주소가 복사 되었어요!'),
+                              (value) => showBottomToast(
+                                context: context,
+                                '링크 주소가 복사 되었어요!',
+                              ),
                             );
                           },
                         ),
@@ -78,7 +81,10 @@ Future<bool?> showMyLinkOptionsDialog(
                                 Navigator.pop(parentContext, 'deleted');
                               }
                               if (result) {
-                                showBottomToast('링크가 삭제되었어요!');
+                                showBottomToast(
+                                  context: context,
+                                  '링크가 삭제되었어요!',
+                                );
                               }
                             });
                           },
@@ -156,9 +162,15 @@ Future<bool?> showChangeFolderDialog(Link link, BuildContext parentContext) {
                                 Navigator.pop(context);
                                 Navigator.pop(context);
                                 if (result) {
-                                  showBottomToast('선택한 폴더로 이동 완료!');
+                                  showBottomToast(
+                                    context: context,
+                                    '선택한 폴더로 이동 완료!',
+                                  );
                                 } else {
-                                  showBottomToast('폴더 이동 실패!');
+                                  showBottomToast(
+                                    context: context,
+                                    '폴더 이동 실패!',
+                                  );
                                 }
                               });
                             },
@@ -426,7 +438,7 @@ void saveEmptyFolder(
   context.read<FolderNameCubit>().add(folder).then((result) {
     if (result) {
       Navigator.pop(context);
-      showBottomToast('새로운 폴더가 생성되었어요!');
+      showBottomToast(context: context, '새로운 폴더가 생성되었어요!');
 
       if (hasNotUnclassified ?? false) {
         parentContext
@@ -449,7 +461,7 @@ void saveEmptyFolder(
         });
       }
     } else {
-      showBottomToast('중복된 폴더 이름입니다!');
+      showBottomToast(context: context, '중복된 폴더 이름입니다!');
     }
   });
 }

--- a/lib/ui/widget/bottom_toast.dart
+++ b/lib/ui/widget/bottom_toast.dart
@@ -1,32 +1,39 @@
 import 'package:ac_project_app/const/colors.dart';
 import 'package:flutter/material.dart';
-import 'package:oktoast/oktoast.dart';
 
-void showBottomToast(String text, {double? bottomPadding}) {
-  showToastWidget(
-    Container(
-      margin:
-      EdgeInsets.only(left: 24, right: 24, bottom: bottomPadding ?? 100),
-      width: double.infinity,
-      height: 38,
-      decoration: const BoxDecoration(
-        borderRadius: BorderRadius.all(Radius.circular(6)),
-        color: grey900,
+void showBottomToast(
+  String text, {
+  double? bottomPadding,
+  BuildContext? context,
+  Function? callback,
+  String actionTitle = '확인하기',
+}) {
+  ScaffoldMessenger.of(context!).showSnackBar(
+    SnackBar(
+      margin: EdgeInsets.only(left: 24, right: 24, bottom: bottomPadding ?? 10),
+      content: Row(
+        mainAxisAlignment: callback == null
+            ? MainAxisAlignment.center
+            : MainAxisAlignment.start,
+        children: [
+          Text(text),
+        ],
       ),
-      child: Center(
-        child: Text(
-          text,
-          style: const TextStyle(
-            color: Colors.white,
-            fontWeight: FontWeight.bold,
-            fontSize: 13,
-            letterSpacing: -0.1,
-          ),
-        ),
+      backgroundColor: grey900,
+      duration: const Duration(milliseconds: 1000),
+      behavior: SnackBarBehavior.floating,
+      action: (callback == null)
+          ? null
+          : SnackBarAction(
+              label: actionTitle,
+              textColor: Colors.white,
+              onPressed: (){
+                callback();
+              },
+            ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(6),
       ),
     ),
-    position: const ToastPosition(align: Alignment.bottomCenter),
-    animationCurve: Curves.ease,
-    animationDuration: Duration.zero,
   );
 }


### PR DESCRIPTION
[fix/#65] 모든 토스트 팝업 + 스낵바 팝업의 경우 하단과 동일한 여백

## 🙋 작업 목적(이슈 내용)

- #62 
- #65 

## 🔧 주요 작업 내용

- 모든 토스트 팝업 + 스낵바 팝업의 경우 하단과 동일한 여백
- 링크 저장완료 시 스낵바 팝업 노출되는 것

## 🙏 To Reviewers

- OkToast 대신 snackBar를 사용하였습니다.
- 링크 저장할때에 업로드 뷰에서 pop이 되고, result ( NavigatorPopResult.saveLink ) 를 받아 SnackBar 를 노출하도록 수정 -> 확인하기 버튼 클릭시 마이폴더로 이동 하게 수정하였습니다.
- 62/65 번 이슈는 MVP 이후 적용이라고 합니다.

