### PR TITLE
[fix/#93] PlayStore 앱 배포 시 경고 제거를 위한 작업

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -75,6 +75,6 @@ jobs:
       - name: Prebuild
         run: flutter build appbundle
       - name: make native debug symbols
-        run: echo 'todo make native debug symbols'
+        run: cd build/app/intermediates/merged_native_libs/release/out/lib && zip -r android/native-debug-symbols.zip . && cd ../../../../../../../
       - name: Execute Fastlane command
         run: cd android && fastlane beta

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,7 +70,11 @@ jobs:
       - run: echo '${{ secrets.ANDROID_KEYSTORE_BASE64 }}' | base64 -d > ./android/monday-key.jks
       - run: echo "${{ secrets.FIREBASE_OPTIONS }}" | base64 -d > ./lib/firebase_options.dart
       - run: echo '${{ secrets.GOOGLE_SERVICES_ANDROID }}' | base64 -d > ./android/app/google-services.json
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1.2.0
       - name: Prebuild
         run: flutter build appbundle
+      - name: make native debug symbols
+        run: echo 'todo make native debug symbols'
       - name: Execute Fastlane command
         run: cd android && fastlane beta

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,7 +42,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 33
-    ndkVersion '25.1.8937393'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -67,6 +66,7 @@ android {
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        ndk.debugSymbolLevel 'FULL'
     }
 
     signingConfigs {
@@ -83,20 +83,9 @@ android {
             shrinkResources true
             minifyEnabled true
             signingConfig signingConfigs.release
-
-            ndk.debugSymbolLevel = "FULL"
         }
     }
     namespace 'com.mr.ac_project_app'
-
-    packagingOptions {
-        dex {
-            useLegacyPackaging true
-        }
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 
 }
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -82,6 +82,7 @@ platform :android do
       skip_upload_apk: true,
       track: 'internal',
       release_status: 'draft',
+      mapping: "native-debug-symbols.zip",
       aab: '../build/app/outputs/bundle/release/app-release.aab'
     )
   end


### PR DESCRIPTION
## 🙋 작업 목적(이슈 내용)

- #93 

## 🔧 주요 작업 내용

- 생성된 디버그 심볼을 fastlane으로 playstore에 업로드 할 때 지정해서 같이 업로드 할 수 있게 하기

## 🙏 To Reviewers

- [이 링크](https://github.com/flutter/flutter/issues/60240)도 함께 읽어 보세요.
